### PR TITLE
Highlight the submit buttons

### DIFF
--- a/templates/css/auth-reset-password.css
+++ b/templates/css/auth-reset-password.css
@@ -61,6 +61,11 @@ input {
     border-radius: 3px;
 }
 
+#submit {
+    border: 0.2rem solid #58D1F5;
+    border-radius: 5px;
+}
+
 @media screen and (min-width: 765px){
     .send-email {
         display: flex;

--- a/templates/css/reset-password.css
+++ b/templates/css/reset-password.css
@@ -61,6 +61,11 @@ input {
     border-radius: 3px;
 }
 
+#submit {
+    border: 0.2rem solid #58D1F5;
+    border-radius: 5px;
+}
+
 @media screen and (min-width: 765px){
     .send-email {
         display: flex;

--- a/templates/html/auth-reset-password.html
+++ b/templates/html/auth-reset-password.html
@@ -20,10 +20,11 @@
             <form action="">
                 <input type="text" name="email" placeholder="Email">
                 <br>
-                <input type="submit">
+                <input type="submit" id="submit">
             </form>
             <a href="../index.html">Back to Sign in</a>
         </div>
     </div>
+    <script src="../scripts/auth-reset-password.js"></script>
 </body>
 </html>

--- a/templates/html/reset-password.html
+++ b/templates/html/reset-password.html
@@ -21,9 +21,10 @@
                 <br>
                 <input type="password" name="confirm_password" placeholder="Confirm Password">
                 <br>
-                <input type="submit">
+                <input type="submit" id="submit">
             </form>
         </div>
     </div>
+    <script src="../scripts/reset-password.js"></script>
 </body>
 </html>

--- a/templates/scripts/auth-reset-password.js
+++ b/templates/scripts/auth-reset-password.js
@@ -1,0 +1,6 @@
+const submitEmail = document.querySelector('#submit');
+
+submitEmail.addEventListener('click', (e) => {
+    e.preventDefault();
+    window.location.href = '../html/reset-password.html';
+});

--- a/templates/scripts/reset-password.js
+++ b/templates/scripts/reset-password.js
@@ -1,0 +1,6 @@
+const submitNewPassword = document.querySelector('#submit');
+
+submitNewPassword.addEventListener('click', (e) => {
+    e.preventDefault();
+    window.location.href = '../html/admin-view-parties.html';
+});


### PR DESCRIPTION
# What does this PR do?

It highlights the submit buttons on `auth-reset-password.html` and `reset-password.html` files

# Description of the tasks to be completed

- Change the color of the call to action buttons
- Link the pages to simulate the user experience when moving from one page to another

# How should this be manually tested?

- Open `auth-reset-password.html` and `reset-password.html` from `/templates/html/`
- Check the color of the submit buttons. They should be light-blue

# What are the relevant pivotal tracker stories?

#171591958

# Screenshots

![Screenshot (125)](https://user-images.githubusercontent.com/52489421/76203518-74a8dd80-61ff-11ea-9e2f-b77354cbe0af.png)
![Screenshot (124)](https://user-images.githubusercontent.com/52489421/76203524-7672a100-61ff-11ea-9df9-464c51ab1830.png)
